### PR TITLE
Fix crash if imageurl is invalid

### DIFF
--- a/Pod/Classes/CollieGalleryView.swift
+++ b/Pod/Classes/CollieGalleryView.swift
@@ -227,14 +227,16 @@ internal class CollieGalleryView: UIView, UIScrollViewDelegate {
                                                         completionHandler:
                     { [weak self] response, data, error in
                     if error == nil {
-                        let image = UIImage(data: data!)!
-                        
-                        DispatchQueue.main.async(execute: {
-                            self?.imageView.image = image
-                            self?.updateImageViewSize()
-                            
-                            self?.activityIndicator.stopAnimating()
-                        })
+                        if let image = UIImage(data: data!) {
+                            DispatchQueue.main.async(execute: {
+                                self?.imageView.image = image
+                                self?.updateImageViewSize()
+                                
+                                self?.activityIndicator.stopAnimating()
+                            })
+                        } else {
+                                self?.activityIndicator.stopAnimating()
+                        }
                     }
                 })
             }


### PR DESCRIPTION
If the image url does not contain an image, the library crashed.